### PR TITLE
Add feature: Allow users to specify world names for alert exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>1.20-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/github/dougcodez/minealert/MineAlert.java
+++ b/src/main/java/io/github/dougcodez/minealert/MineAlert.java
@@ -5,6 +5,7 @@ import io.github.dougcodez.minealert.command.MineAlertCommand;
 import io.github.dougcodez.minealert.command.SubCommandRegistry;
 import io.github.dougcodez.minealert.file.DatabaseFile;
 import io.github.dougcodez.minealert.file.MineAlertSettingsFile;
+import io.github.dougcodez.minealert.file.WorldsFile;
 import io.github.dougcodez.minealert.file.inventory.InspectMenuSettingsFile;
 import io.github.dougcodez.minealert.file.lang.LangFile;
 import io.github.dougcodez.minealert.gui.listener.GUIListeners;
@@ -31,6 +32,7 @@ public class MineAlert extends JavaPlugin {
     private InspectMenuSettingsFile inspectMenuSettingsFile;
     private MiningUserManager miningUserManager;
     private MiningUserDataHandler userDataHandler;
+    private WorldsFile worldsFile;
 
     @Getter
     private static int interval;
@@ -60,6 +62,7 @@ public class MineAlert extends JavaPlugin {
         statementAPI = new StatementAPI();
         miningUserManager = new MiningUserManager();
         userDataHandler = new MiningUserDataHandler();
+        worldsFile = new WorldsFile();
     }
 
     private void registerRegistries() {
@@ -74,7 +77,7 @@ public class MineAlert extends JavaPlugin {
         databaseFile.registerFile();
         mineAlertSettingsFile.registerFile();
         inspectMenuSettingsFile.registerFile();
-
+        worldsFile.registerFile();
     }
 
     private void registerDatabase() {

--- a/src/main/java/io/github/dougcodez/minealert/command/types/ReloadFilesCommand.java
+++ b/src/main/java/io/github/dougcodez/minealert/command/types/ReloadFilesCommand.java
@@ -38,6 +38,7 @@ public class ReloadFilesCommand extends SubCommand {
         MineAlert.getInstance().getMineAlertSettingsFile().reloadFile("mine-alert-settings.yml");
         MineAlert.getInstance().getLangFile().reloadFile("messages.yml");
         MineAlert.getInstance().getDatabaseFile().reloadFile("database-settings.yml");
+        MineAlert.getInstance().getWorldsFile().reloadFile("worlds.yml");
         sender.sendMessage(FormatUtils.color(Lang.PREFIX.toConfigString() + Lang.RELOAD_MESSAGE));
     }
 }

--- a/src/main/java/io/github/dougcodez/minealert/file/WorldsFile.java
+++ b/src/main/java/io/github/dougcodez/minealert/file/WorldsFile.java
@@ -1,0 +1,23 @@
+package io.github.dougcodez.minealert.file;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WorldsFile extends AbstractFile{
+    @Override
+    public void registerFile() {
+        createFile("worlds.yml");
+        setData();
+        saveFile();
+    }
+
+    @Override
+    public void setData() {
+        if (isFileNotEmpty()) return;
+        final FileConfiguration config = getFileConfiguration();
+        config.set("worlds", List.of("example_world"));
+        config.setComments("worlds", List.of("Enter the worlds where you want the alerts to be disabled"));
+    }
+}

--- a/src/main/java/io/github/dougcodez/minealert/listener/BlockBreakListener.java
+++ b/src/main/java/io/github/dougcodez/minealert/listener/BlockBreakListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -178,6 +179,10 @@ public class BlockBreakListener implements Listener {
 
 
     private void alertStaff(Player player, MiningDataProperties dataProperty) {
+        if (MineAlert.getInstance().getWorldsFile().getFileConfiguration().getStringList("worlds")
+                .stream()
+                .anyMatch(world -> world.equalsIgnoreCase(player.getWorld().getName())))
+            return;
         if (!dataProperty.matchesPriorities()) return;
         UUID playerUUID = player.getUniqueId();
         if (dataProperty.getCacheValue(playerUUID) >= dataProperty.getMinVL()) {


### PR DESCRIPTION
I implemented a new feature that enables users to customize alert preferences by specifying world names where they do not want alerts to be enabled. This is particularly useful for scenarios such as public mines, where constant alerts are not necessary.